### PR TITLE
LLM Registry can shutdown  and restart LLM_Wrapper

### DIFF
--- a/.github/workflows/sonarcube.yml
+++ b/.github/workflows/sonarcube.yml
@@ -29,19 +29,3 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           args: -Dsonar.python.coverage.reportPaths=reports/coverage.xml
-      - name: Update Status in GitHub
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { context } = require('@actions/github');
-            const status = context.payload.workflow_run.conclusion === 'success' ? 'success' : 'failure';
-            await github.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.payload.workflow_run.head_commit.id,
-              state: status,
-              context: 'SonarQube Quality Gate',
-              description: 'SonarQube Quality Gate Check',
-              target_url: context.run.html_url
-            });

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytest
 pytest-mock
 fastapi[standard]
 httpx
+paramiko

--- a/src/app/controller/db_controller.py
+++ b/src/app/controller/db_controller.py
@@ -158,6 +158,8 @@ class LLMRegistryDbController:
             ("llm", "TEXT"),
             ("llm_config", "TEXT"),
             ("address", "TEXT"),
+            ("username", "TEXT"),
+            ("password", "TEXT"),
             ("status", "TEXT")
         ])
         self.db_controller.create_table("llm_request", [
@@ -187,8 +189,8 @@ class LLMRegistryDbController:
     def get_all_wrappers(self):
         return self.db_controller.fetch_all("llm_wrapper")
         
-    def add_llm_wrapper(self, name: str, config: str, address: str, status: str):
-        self.db_controller.insert_data("llm_wrapper", [(name, config, address, status)])
+    def add_llm_wrapper(self, name: str, config: str, address: str, username: str, password: str, status: str):
+        self.db_controller.insert_data("llm_wrapper", [(name, config, address, username, password, status)])
         
     def get_llm_wrappers(self):
         console_logger.info("Fetching all LLM wrappers...")

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,8 +1,38 @@
+from contextlib import asynccontextmanager
 from fastapi import FastAPI
 import app.services.llm_registry_service as llm_registry_service
+import app.services.llm_wrapper_status_service as llm_wrapper_status_service
+from app.utils.configreader import ConfigReader
 from app.controller.promptingservice_controller import router as promptingservice_controller
+from app.utils.logger import console_logger
 
-app = FastAPI()
+configreader = ConfigReader.get_instance()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    console_logger.info("Starting up the application")
+    #@TODO: read the config for the llm_wrapper_machines and write them to the db
+    
+    #start the check status thread
+    llm_wrapper_status_service.start_check_status()
+    #start the registry service queue
+    llm_registry_service.start()
+    
+    yield
+    
+    console_logger.info("Shutting down the application")
+    
+    #stop the check status thread
+    llm_wrapper_status_service.stop_check_status()
+    #stop the registry service queue
+    llm_registry_service.shutdown()
+    
+    #@TODO: stop all llm_wrapper_machines
+    #llm_wrapper_service.shutdown_wrapper()
+    
+
+
+app = FastAPI(lifespan=lifespan)
 
 app.include_router(promptingservice_controller, prefix="/promptingservice", tags=["SomeController"])
 

--- a/src/app/services/llm_wrapper_service.py
+++ b/src/app/services/llm_wrapper_service.py
@@ -27,3 +27,13 @@ def stop_llm(lm_address: str):
     else:
         console_logger.error(f"Failed to stop LLM: {response}")
         return False
+    
+def shutdown_wrapper(wrapper_address: str, username: str, password: str):
+    response = wrapper_client.stop_wrapper(wrapper_address, password, username)
+    if response:
+        console_logger.info(f"Wrapper shutdown successfully: {response}")
+        return True
+    else:
+        console_logger.error(f"Failed to shutdown Wrapper: {response}")
+        return False
+   

--- a/src/app/utils/logger.py
+++ b/src/app/utils/logger.py
@@ -6,7 +6,6 @@ class Logger:
         if filename is None:
             # Log to console
             logging.basicConfig(
-                stream=sys.stdout,
                 level=logging.DEBUG,
                 format="%(asctime)s - %(levelname)s - %(message)s"
             )

--- a/src/tests/controller/test_db_controller.py
+++ b/src/tests/controller/test_db_controller.py
@@ -50,6 +50,8 @@ def test_table_creation(mock_db_controller, mock_config_reader):
             ("llm", "TEXT"),
             ("llm_config", "TEXT"),
             ("address", "TEXT"),
+            ("username", "TEXT"),
+            ("password", "TEXT"),
             ("status", "TEXT")
         ])
     
@@ -73,9 +75,9 @@ def test_insert_wrapper(mock_db_controller, mock_config_reader):
     
         db_controller = LLMRegistryDbController.get_instance()
         
-        db_controller.add_llm_wrapper("llm", "config", "address", "status")
+        db_controller.add_llm_wrapper("llm", "config", "address", "root", "password", "status")
         
-        mock_db_controller.insert_data.assert_called_once_with("llm_wrapper", [("llm", "config", "address", "status")])
+        mock_db_controller.insert_data.assert_called_once_with("llm_wrapper", [("llm", "config", "address", "root", "password", "status")])
         
 def test_get_llm_wrappers(mock_db_controller, mock_config_reader):
         

--- a/src/tests/services/test_llm_wrapper_status_service.py
+++ b/src/tests/services/test_llm_wrapper_status_service.py
@@ -2,12 +2,21 @@ import pytest
 import time
 from unittest.mock import MagicMock, patch
 from app.services.llm_wrapper_status_service import check_status
+from app.controller.db_controller import LLMRegistryDbController
+
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    # Vor jedem Test das Singleton zurücksetzen
+    LLMRegistryDbController._instance = None
+    yield
+    # Nach dem Test kannst du es optional auch wieder auf None setzen
+    LLMRegistryDbController._instance = None
 
 def test_status_check(mocker):
     running_values = iter([True, False])  # Erst True, dann False
     mock_db_controller = mocker.patch("app.services.llm_wrapper_status_service.LLMRegistryDbController")
     mock_db_controller.get_instance.return_value = mock_db_controller
-    mock_db_controller.get_all_wrappers.return_value = [{"address": "http://localhost:5000", "id": 1}]
+    mock_db_controller.get_all_wrappers.return_value = [{"address": "http://localhost:5000", "id": 1, "status": "ready"}]
     mock_db_controller.change_llm_wrapper_status_by_id.return_value = "ready"
     
     mock_wrapper_client = mocker.patch("app.services.llm_wrapper_status_service.wrapper_client")
@@ -19,3 +28,97 @@ def test_status_check(mocker):
     mock_db_controller.get_all_wrappers.assert_called()
     mock_wrapper_client.check_status.assert_called_with("http://localhost:5000")
     mock_db_controller.change_llm_wrapper_status_by_id.assert_called_with(1, "ready")
+    
+def test_status_not_checked_if_deployment(mocker):
+    running_values = iter([True, False])  # Erst True, dann False
+    mock_db_controller = mocker.patch("app.services.llm_wrapper_status_service.LLMRegistryDbController")
+    mock_db_controller.get_instance.return_value = mock_db_controller
+    mock_db_controller.get_all_wrappers.return_value = [{"address": "http://localhost:5000", "id": 1, "status": "deploying"}]
+    mock_db_controller.change_llm_wrapper_status_by_id.return_value = "deploying"
+    
+    mock_wrapper_client = mocker.patch("app.services.llm_wrapper_status_service.wrapper_client")
+    mock_wrapper_client.check_status.return_value = "deploying"
+    mocker.patch("app.services.llm_wrapper_status_service.is_running", side_effect=lambda: next(running_values))
+    mocker.patch("app.services.llm_wrapper_status_service.time.sleep", side_effect=lambda x: None)
+
+    check_status()
+    mock_db_controller.get_all_wrappers.assert_called()
+    mock_wrapper_client.check_status.assert_not_called()
+    mock_db_controller.change_llm_wrapper_status_by_id.assert_not_called()
+    
+def test_status_not_checked_if_stopping(mocker):
+    running_values = iter([True, False])  # Erst True, dann False
+    mock_db_controller = mocker.patch("app.services.llm_wrapper_status_service.LLMRegistryDbController")
+    mock_db_controller.get_instance.return_value = mock_db_controller
+    mock_db_controller.get_all_wrappers.return_value = [{"address": "http://localhost:5000", "id": 1, "status": "stopping"}]
+    mock_db_controller.change_llm_wrapper_status_by_id.return_value = "stopping"
+    
+    mock_wrapper_client = mocker.patch("app.services.llm_wrapper_status_service.wrapper_client")
+    mock_wrapper_client.check_status.return_value = "stopping"
+    mocker.patch("app.services.llm_wrapper_status_service.is_running", side_effect=lambda: next(running_values))
+    mocker.patch("app.services.llm_wrapper_status_service.time.sleep", side_effect=lambda x: None)
+
+    check_status()
+    mock_db_controller.get_all_wrappers.assert_called()
+    mock_wrapper_client.check_status.assert_not_called()
+    mock_db_controller.change_llm_wrapper_status_by_id.assert_not_called()
+    
+def test_status_not_checked_if_restarting(mocker):
+    running_values = iter([True, False])  # Erst True, dann False
+    mock_db_controller = mocker.patch("app.services.llm_wrapper_status_service.LLMRegistryDbController")
+    mock_db_controller.get_instance.return_value = mock_db_controller
+    mock_db_controller.get_all_wrappers.return_value = [{"address": "http://localhost:5000", "id": 1, "status": "restarting"}]
+    mock_db_controller.change_llm_wrapper_status_by_id.return_value = "restarting"
+    
+    mock_wrapper_client = mocker.patch("app.services.llm_wrapper_status_service.wrapper_client")
+    mock_wrapper_client.check_status.return_value = "restarting"
+    mocker.patch("app.services.llm_wrapper_status_service.is_running", side_effect=lambda: next(running_values))
+    mocker.patch("app.services.llm_wrapper_status_service.time.sleep", side_effect=lambda x: None)
+
+    check_status()
+    mock_db_controller.get_all_wrappers.assert_called()
+    mock_wrapper_client.check_status.assert_not_called()
+    mock_db_controller.change_llm_wrapper_status_by_id.assert_not_called()
+    
+import pytest
+from unittest.mock import patch
+
+def test_redeployment_when_status_failure(mocker):
+    # Immitiere, dass die Schleife 1-mal durchläuft (True) und dann stoppt (False).
+    running_values = iter([True, False])
+    
+    # Patch DB-Controller
+    mock_db_controller = mocker.patch("app.services.llm_wrapper_status_service.LLMRegistryDbController")
+    mock_db_controller.get_instance.return_value = mock_db_controller
+    mock_db_controller.get_all_wrappers.return_value = [{
+        "address": "http://localhost:5000",
+        "id": 1,
+        "status": "failure",
+        "username": "root",
+        "password": "secret"
+    }]
+    
+    # Patch `is_running` damit die while-Schleife nur einmal durchläuft
+    mocker.patch("app.services.llm_wrapper_status_service.is_running", side_effect=lambda: next(running_values))
+    # Zeitpatch, damit kein echtes Sleep passiert
+    mocker.patch("app.services.llm_wrapper_status_service.time.sleep", side_effect=lambda x: None)
+    
+    # **Wichtig**: Patch die Funktion, die den Thread startet:
+    with patch("app.services.llm_wrapper_status_service.restart_wrapper_in_background") as mock_restart_bg:
+        from app.services.llm_wrapper_status_service import check_status
+        check_status()
+
+        # 1) Wurde "get_all_wrappers" aufgerufen?
+        mock_db_controller.get_all_wrappers.assert_called_once()
+
+        # 2) Status muss auf "restarting" gesetzt werden
+        mock_db_controller.change_llm_wrapper_status_by_id.assert_any_call(1, "restarting")
+        
+        # 3) Wurde die „Hintergrund-Neustart“-Funktion aufgerufen?
+        mock_restart_bg.assert_called_once_with(
+            1,
+            "http://localhost:5000",
+            "secret",
+            "root"
+        )
+

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -1,0 +1,33 @@
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+
+def test_app_lifespan_in_one_go():
+    """
+    Prüft Startup und Shutdown in *einem* Test, inklusive Aufrufen 
+    von start_check_status/stop_check_status und start/shutdown.
+    """
+    with patch("app.main.llm_wrapper_status_service.start_check_status") as mock_start_check, \
+         patch("app.main.llm_wrapper_status_service.stop_check_status") as mock_stop_check, \
+         patch("app.main.llm_registry_service.start") as mock_registry_start, \
+         patch("app.main.llm_registry_service.shutdown") as mock_registry_shutdown:
+
+        # Jetzt erst importieren wir 'app', damit die oben gesetzten Patches greifen
+        from app.main import app
+
+        # 1) Erstellen des TestClients => Startup wird getriggert
+        with TestClient(app) as client:
+            # Direkt nach dem Erstellen sollte Startup bereits passiert sein:
+            mock_start_check.assert_called_once()
+            mock_registry_start.assert_called_once()
+
+            # 2) Testen wir einen normalen Request
+            resp = client.get("/")
+            assert resp.status_code == 200
+            assert resp.json() == {"message": "Hello World"}
+
+        # 3) Beim Verlassen des `with TestClient(app)` => Shutdown
+        #    Jetzt sollte stop_check_status & shutdown aufgerufen worden sein.
+        mock_stop_check.assert_called_once()
+        mock_registry_shutdown.assert_called_once()

--- a/src/tests/utils/test_configreader.py
+++ b/src/tests/utils/test_configreader.py
@@ -3,6 +3,14 @@ import time
 from unittest.mock import MagicMock, patch
 from app.utils.configreader import ConfigReader
 
+@pytest.fixture(autouse=True)
+def reset_singleton():
+    # Vor jedem Test das Singleton zurücksetzen
+    ConfigReader._instance = None
+    yield
+    # Nach dem Test kannst du es optional auch wieder auf None setzen
+    ConfigReader._instance = None
+
 def test_get(mocker):
     
     mock_configparser = mocker.patch("app.utils.configreader.configparser")


### PR DESCRIPTION
close #15 #16 

This PR enables the LLM-Registry to shutdown or restart any LLM-Wrapper by connecting to its hostmachine via SSH
